### PR TITLE
Clean up "TODOs"

### DIFF
--- a/lib/net/server/handler.go
+++ b/lib/net/server/handler.go
@@ -15,7 +15,10 @@ func handlerFunc(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	begin := time.Now()
-	record := records.NewRecord(r, cfg.Listener(), store)
+	record := records.NewRecord(r, cfg.Listener())
+	if store != nil {
+		store.Add(record)
+	}
 
 	respFmt := defaultFmt
 	if record.Echo {

--- a/lib/net/server/server.go
+++ b/lib/net/server/server.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -60,20 +59,9 @@ func Start(c *config.Config) error {
 		stream = &recorder.StdRecorder{}
 		format := formatter.NoopClient{}
 
-		// TODO: Make StdFormatter#WriteHeader function to handle this for all things.
 		if c.StreamRecord {
 			format.NewLine = true
-
-			head := fmt.Sprintf("# Stream started: %s\n", time.Now().Format("Mon Jan 2 15:04:05 MST 2006"))
-			_, err := file.WriteString(head)
-			if err != nil {
-				return errors.Errorf("error writing to stream file: %v", err)
-			}
-
-			err = file.Sync()
-			if err != nil {
-				return errors.Errorf("error syncing to stream file: %v", err)
-			}
+			stream.WriteTimestamp()
 
 			// To ensure things are flushed correctly
 			defer file.Sync()

--- a/lib/recorder/recorder.go
+++ b/lib/recorder/recorder.go
@@ -16,12 +16,22 @@ type Recorder interface {
 	SetWriter(*os.File)
 	WriteOne(records.Record) error
 	WriteAll(*records.RecordMap) error
+	WriteTimestamp()
 }
 
 // This will support anything that implements the 'io.Writer' interface.
 type StdRecorder struct {
 	formatter formatter.RecordsFormatter
 	writer    *os.File
+}
+
+// This is idempotent, and will fail quietly.
+func (r *StdRecorder) WriteTimestamp() {
+	ts := r.formatter.FormatTimestamp()
+	if ts != "" {
+		r.writer.Write([]byte(ts))
+		r.writer.Sync()
+	}
 }
 
 func (r *StdRecorder) SetFormatter(f formatter.RecordsFormatter) {

--- a/lib/recorder/recorder_test.go
+++ b/lib/recorder/recorder_test.go
@@ -29,7 +29,7 @@ func request() *http.Request {
 
 func record() records.Record {
 	req := request()
-	r := records.NewRecord(req, "test.host:3333", nil)
+	r := records.NewRecord(req, "test.host:3333")
 	r.Iterations = 1
 	r.Status = http.StatusOK
 	r.Sleep = 0

--- a/lib/records/formatter/echo.go
+++ b/lib/records/formatter/echo.go
@@ -11,7 +11,9 @@ import (
 
 const ECHO_TEMPLATE = "status='%d %s' method=%s path=%s headers='%v'"
 
-type Echo struct{}
+type Echo struct {
+	Default
+}
 
 func (f Echo) FormatRecordMap(mapped *records.RecordMap) string {
 	return commonFormatRecordMap(f, mapped)

--- a/lib/records/formatter/formatter.go
+++ b/lib/records/formatter/formatter.go
@@ -22,6 +22,7 @@ type RecordsFormatter interface {
 	FormatRecordMap(*records.RecordMap) string
 	FormatRecord(records.Record) string
 	FormatHeader(*http.Header) string
+	FormatTimestamp() string
 }
 
 func NewFromString(formatter string) RecordsFormatter {
@@ -56,6 +57,10 @@ func (f Default) FormatHeader(headers *http.Header) string {
 	}
 
 	return commonFormatHeader(headers)
+}
+
+func (f Default) FormatTimestamp() string {
+	return "" // default to no timestamp
 }
 
 // Common - reuse in more than one

--- a/lib/records/formatter/formatter_test.go
+++ b/lib/records/formatter/formatter_test.go
@@ -33,7 +33,7 @@ func request() *http.Request {
 
 func record() records.Record {
 	req := request()
-	r := records.NewRecord(req, "", nil)
+	r := records.NewRecord(req, "")
 	r.Iterations = 1
 	r.Status = http.StatusOK
 	r.Sleep = 0

--- a/lib/records/formatter/log.go
+++ b/lib/records/formatter/log.go
@@ -13,6 +13,7 @@ import (
 const LOG_TEMPLATE = "on=%s method=%s path=%s status=%d took=%v\n"
 
 type Log struct {
+	Default
 	verbose  bool
 	caller   string
 	duration time.Duration

--- a/lib/records/formatter/noop_client.go
+++ b/lib/records/formatter/noop_client.go
@@ -28,7 +28,7 @@ func (f NoopClient) FormatRecordMap(mapped *records.RecordMap) string {
 		out = ts + out
 	}
 
-	return out
+	return out + "\n"
 }
 
 func (f NoopClient) FormatRecord(r records.Record) string {

--- a/lib/records/formatter/noop_client.go
+++ b/lib/records/formatter/noop_client.go
@@ -13,7 +13,6 @@ import (
 )
 
 // # Format is '{iterations:-1}|{method:-GET}|{endpoint}|{headers:-}|{sleep}
-// TODO: NoopClient needs a host somehow
 const NOOP_CLEINT_TEMPLATE = "%d|%s|%s|%s|%v"
 
 type NoopClient struct {

--- a/lib/records/formatter/noop_client.go
+++ b/lib/records/formatter/noop_client.go
@@ -16,15 +16,19 @@ import (
 const NOOP_CLEINT_TEMPLATE = "%d|%s|%s|%s|%v"
 
 type NoopClient struct {
+	Default
 	NewLine bool
 }
 
 func (f NoopClient) FormatRecordMap(mapped *records.RecordMap) string {
-	return fmt.Sprintf(
-		"# Created: %s\n%s\n",
-		time.Now().Format("Mon Jan 2 15:04:05 MST 2006"),
-		commonFormatRecordMap(f, mapped),
-	)
+	out := commonFormatRecordMap(f, mapped)
+
+	ts := f.FormatTimestamp()
+	if ts != "" {
+		out = ts + out
+	}
+
+	return out
 }
 
 func (f NoopClient) FormatRecord(r records.Record) string {
@@ -50,4 +54,8 @@ func (f NoopClient) FormatHeader(headers *http.Header) string {
 	}
 
 	return commonFormatHeader(headers)
+}
+
+func (f NoopClient) FormatTimestamp() string {
+	return fmt.Sprintf("# Started: %s\n", time.Now().Format("Mon Jan 2 15:04:05 MST 2006"))
 }

--- a/lib/records/record.go
+++ b/lib/records/record.go
@@ -10,16 +10,10 @@ import (
 	"time"
 )
 
-// TODO: Consider making MAX_SLEEP a cli arg
 const MAX_SLEEP = (15 * time.Second)
-
-// TODO: Consider making RECORD_HEADER a cli arg
 const RECORD_HEADER = "X-Noopserverflags"
-
 const SPLIT_RECORD_HEADER = ";"
 const SPLIT_HEADER_VALUE = ":"
-
-// TODO: Consider making DEFAULT_STATUS a cli arg
 const DEFAULT_STATUS = http.StatusOK
 
 // Used to create a string for hashing a Record
@@ -30,20 +24,16 @@ type Record struct {
 	Headers    *http.Header
 	endpoint   *url.URL // internal holder for raw url struct
 	Method     string
-
-	// TODO: Record - Consider using fetcher methods for Status and Sleep to ensure safty
-	Status int
-	Sleep  time.Duration
-
-	// TODO: Record - Support Body in Record, perhapse instead of Echo
-	Echo bool
+	Status     int
+	Sleep      time.Duration
+	Echo       bool
 }
 
 func GetStore() *RecordMap {
 	return defaultStore
 }
 
-func NewRecord(req *http.Request, dHost string, store *RecordMap) Record {
+func NewRecord(req *http.Request, dHost string) Record {
 	r := Record{}
 
 	// Because this will parse a single request, the iterations will always be 1
@@ -62,11 +52,6 @@ func NewRecord(req *http.Request, dHost string, store *RecordMap) Record {
 
 	// Values from http.Header
 	r.parseValuesFromHeader()
-
-	// TODO: In NewRecord why am I handling mapping automatically.
-	if store != nil {
-		store.Add(r)
-	}
 
 	return r
 }
@@ -139,7 +124,6 @@ func (r *Record) parseValuesFromHeader() {
 
 }
 
-// TODO: Record.parseStatus - consider return error
 func (r *Record) parseStatus(s string) {
 	if i, e := strconv.ParseInt(s, 10, 16); e == nil {
 		r.Status = int(i)
@@ -150,7 +134,6 @@ func (r *Record) parseStatus(s string) {
 	r.Status = DEFAULT_STATUS
 }
 
-// TODO: Record.parseSleep - consider return error
 func (r *Record) parseSleep(s string) {
 	// Support direct duration format - e.g. 1s 2ms, etc.
 	dur, err := time.ParseDuration(s)

--- a/lib/records/record_map.go
+++ b/lib/records/record_map.go
@@ -56,6 +56,18 @@ func (rm *RecordMap) Size() int {
 	return len(rm.store)
 }
 
+func (rm *RecordMap) Iterations() int {
+	unlock := rm.rLocker()
+	defer unlock()
+	var i int
+
+	for _, val := range rm.store {
+		i += val.Iterations
+	}
+
+	return i
+}
+
 func (rm *RecordMap) rwLocker() func() {
 	rm.mux.Lock()
 	return rm.mux.Unlock

--- a/lib/records/record_map.go
+++ b/lib/records/record_map.go
@@ -40,8 +40,6 @@ func (rm *RecordMap) Snapshot() map[string]Record {
 	return rm.store
 }
 
-// TODO Consider adding RecordMap#Each, currently no use for it
-
 // This function is only used for testing, making private.
 // It should be tested in both fetch and read and fetch and
 // write conditions before being made public.

--- a/lib/records/record_test.go
+++ b/lib/records/record_test.go
@@ -41,7 +41,7 @@ func TestRecord_NewRecord(t *testing.T) {
 
 	defHost := "localhost:3000"
 
-	record := NewRecord(request, defHost, nil)
+	record := NewRecord(request, defHost)
 
 	if record.Iterations != 1 {
 		t.Error("Expected record.Iterations to be 1, got", record.Iterations)
@@ -80,7 +80,7 @@ func TestRecord_NewRecord_withRequestHost(t *testing.T) {
 	request := &http.Request{
 		Host: "https://host.test.host",
 	}
-	record := NewRecord(request, "", nil)
+	record := NewRecord(request, "")
 
 	if record.endpoint.Scheme != "https" {
 		t.Error("Expected record.endpoint.Schmeme to be https, got", record.endpoint.Scheme)
@@ -93,7 +93,7 @@ func TestRecord_NewRecord_withRequestHost(t *testing.T) {
 
 func TestRecord_NewRecord_withDefaultHost(t *testing.T) {
 	request := &http.Request{}
-	record := NewRecord(request, "https://default.test.host:3333", nil)
+	record := NewRecord(request, "https://default.test.host:3333")
 
 	if record.endpoint.Scheme != "https" {
 		t.Error("Expected record.endpoint.Schmeme to be https, got", record.endpoint.Scheme)

--- a/test/load.sh
+++ b/test/load.sh
@@ -2,7 +2,6 @@
 
 function do_curl {
   curl -H 'X-NoopServerFlags:echo;sleep=500ms;status=301' -d 'foo=bar' localhost:3000/load/$1
-  echo
 }
 
 while true


### PR DESCRIPTION
Updates
- Don't handle store in records.NewRecord
- Move timestamp header for noop-client format out of server.

Addressing or removing the following TODOs
- TODO: Make StdFormatter#WriteHeader function to handle this for all things.
- TODO: NoopClient needs a host somehow
- TODO: Consider making MAX_SLEEP a cli arg
- TODO: Consider making RECORD_HEADER a cli arg
- TODO: Consider making DEFAULT_STATUS a cli arg
- TODO: Record - Consider using fetcher methods for Status and Sleep to ensure safty
- TODO: Record - Support Body in Record, perhapse instead of Echo
- TODO: In NewRecord why am I handling mapping automatically.
- TODO: Record.parseStatus - consider return error
- TODO: Record.parseSleep - consider return error
- TODO Consider adding RecordMap#Each, currently no use for it
